### PR TITLE
Add execution logging

### DIFF
--- a/src/funding.ts
+++ b/src/funding.ts
@@ -36,6 +36,7 @@ export async function showDeposits(): Promise<FundingResult> {
     });
 
     const netTotal = gross - feeSum;
+    console.log(`[Funding] Deposits loaded: ${items.length}`);
     return {
         items,
         gross,
@@ -64,6 +65,7 @@ export async function showWithdrawals(): Promise<FundingResult> {
     });
 
     const netTotal = gross + feeSum;
+    console.log(`[Funding] Withdrawals loaded: ${items.length}`);
     return {
         items,
         gross,

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,6 +139,7 @@ async function load() {
         throw new Error('#content element not found');
     }
 
+    console.log('[Main] Loading page data');
     try {
         const fundingRes = await fetch('/api/funding');
         if (!fundingRes.ok) {
@@ -167,6 +168,7 @@ async function load() {
             renderCoinTable(summary);
         
         el.innerHTML = html;
+        console.log('[Main] Page data loaded');
 
     } catch (err: any) {
         el.innerHTML = `<p style="color:red">Fehler: ${err.message}</p>`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,10 +7,12 @@ const app = express();
 const port = process.env.PORT ?? 3000;
 
 app.get('/api/funding', async (_req, res) => {
+    console.log('GET /api/funding');
     try {
         const deposits = await showDeposits();
         const withdrawals = await showWithdrawals();
         res.json({ deposits, withdrawals });
+        console.log('[Funding API] success');
     } catch (err: any) {
         console.error('[Funding API] ➜', err.message);
         res.status(500).json({ error: err.message });
@@ -18,10 +20,12 @@ app.get('/api/funding', async (_req, res) => {
 });
 
 app.get('/api/trades', async (_req, res) => {
+    console.log('GET /api/trades');
     try {
         const buys = await showBuys();
         const sells = await showSells();
         res.json({ buys, sells });
+        console.log('[Trades API] success');
     } catch (err: any) {
         console.error('[Trades API] ➜', err.message);
         res.status(500).json({ error: err.message });
@@ -29,9 +33,11 @@ app.get('/api/trades', async (_req, res) => {
 });
 
 app.get('/api/coin-summary', async (_req, res) => {
+    console.log('GET /api/coin-summary');
     try {
         const coinSummary = await showCoinSummary();
         res.json(coinSummary);
+        console.log('[CoinSummary API] success');
     } catch (err: any) {
         console.error('[CoinSummary Api] ➜', err.message);
         res.status(500).json({ error: err.message });

--- a/src/trade.ts
+++ b/src/trade.ts
@@ -37,7 +37,9 @@ export interface CoinSummary {
 
 async function laodTradesRaw() {
     const res = await krakenPost('/0/private/TradesHistory');
-    return Object.values(res.trades ?? {}) as any[];    
+    const rows = Object.values(res.trades ?? {}) as any[];
+    console.log(`[Trades] Loaded ${rows.length} trades from API`);
+    return rows;
 }
 
 function mapTrade(raw: any): TradeItem {
@@ -84,7 +86,7 @@ export async function showBuys(): Promise<TradeResult> {
 
     const instantRows = await getInstantBuys();
     const instantItems = instantRows.map(convertInstant);
-
+    console.log(`[Trades] Buys: ${proItems.length} pro, ${instantItems.length} instant`);
     return appendTotals([...proItems, ...instantItems]);
 }
 
@@ -92,6 +94,7 @@ export async function showSells(): Promise<TradeResult> {
     const items = (await laodTradesRaw())
                     .filter(r => r.type === 'sell')
                     .map(mapTrade);
+    console.log(`[Trades] Sells loaded: ${items.length}`);
     return appendTotals(items);
 }
 

--- a/src/utils/kraken.ts
+++ b/src/utils/kraken.ts
@@ -32,7 +32,17 @@ export async function krakenPost(path: string) {
         'API-Sign': sign(path, params, SECRET!),
         'Content-Type': 'application/x-www-form-urlencoded'
     };
-    const { data } = await axios.post(API_URL + path, params, { headers });
-    if (data.error?.length) throw new Error(data.error.join('; '));
-    return data.result;
+
+    console.log(`[Kraken] POST ${path}`);
+    try {
+        const { data } = await axios.post(API_URL + path, params, { headers });
+        if (data.error?.length) {
+            console.error(`[Kraken] Error: ${data.error.join('; ')}`);
+            throw new Error(data.error.join('; '));
+        }
+        return data.result;
+    } catch (err: any) {
+        console.error(`[Kraken] Request failed: ${err.message}`);
+        throw err;
+    }
 }


### PR DESCRIPTION
## Summary
- log Kraken API requests and failures
- log counts of deposits, withdrawals, and trades processed
- log when Express API routes are hit and succeed
- log page load events for client debugging

## Testing
- `npm run build` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860dfc4ea84832ab5fe146710ef6246