### PR TITLE
Log number of pairs from fetchPrices

### DIFF
--- a/src/utils/kraken.ts
+++ b/src/utils/kraken.ts
@@ -75,5 +75,6 @@ export async function fetchPrices(pairs: string[]): Promise<Record<string, Price
             ts: new Date().toISOString(),
         };
     });
+    info(`[Kraken] Returned ${Object.keys(out).length} pairs`);
     return out;
 }


### PR DESCRIPTION
## Summary
- log count of returned pairs in `fetchPrices`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68612bf09848832a8cc9ea89b75e3106