### PR TITLE
Add info logs for function entry

### DIFF
--- a/src/funding.ts
+++ b/src/funding.ts
@@ -18,6 +18,7 @@ export interface FundingResult {
 }
 
 export async function showDeposits(): Promise<FundingResult> {
+    info('[Funding] showDeposits start');
     const res = await krakenPost('/0/private/DepositStatus');
     let gross = 0, feeSum = 0;
 
@@ -47,6 +48,7 @@ export async function showDeposits(): Promise<FundingResult> {
 }
 
 export async function showWithdrawals(): Promise<FundingResult> {
+    info('[Funding] showWithdrawals start');
     const res = await krakenPost('/0/private/WithdrawStatus');
     let gross = 0, feeSum = 0;
 

--- a/src/ledger.ts
+++ b/src/ledger.ts
@@ -1,6 +1,7 @@
 import { krakenPost } from "./utils/kraken";
 import { dt } from "./utils/dt";
 import { mapKrakenAsset } from "./utils/assetMapper";
+import { info } from "./utils/logger";
 
 export interface InstantTrade {
     time: string;
@@ -26,6 +27,7 @@ export interface RewardItem {
 }
 
 export async function getInstantTrades(): Promise<InstantTrade[]> {
+    info('[Ledger] getInstantTrades start');
     const { ledger } = await krakenPost('/0/private/Ledgers');
     const rows = Object.values(ledger ?? {}) as any[];
 
@@ -55,6 +57,7 @@ export async function getInstantTrades(): Promise<InstantTrade[]> {
 }
 
 export async function getBaseFees(): Promise<BaseFee[]> {
+    info('[Ledger] getBaseFees start');
     const { ledger } = await krakenPost('/0/private/Ledgers');
     return Object.values(ledger ?? {})
         .filter((r: any) => 
@@ -71,6 +74,7 @@ export async function getBaseFees(): Promise<BaseFee[]> {
 }
 
 export async function getRewards(): Promise<RewardItem[]> {
+    info('[Ledger] getRewards start');
     const { ledger } = await krakenPost("/0/private/Ledgers");
     return Object.values(ledger ?? {})
         .filter((r: any) => r.type === "reward" && Number(r.amount) > 0)

--- a/src/trade.ts
+++ b/src/trade.ts
@@ -43,6 +43,7 @@ export interface CoinSummary {
 }
 
 async function loadTradesRaw() {
+    info('[Trades] loadTradesRaw start');
     const res = await krakenPost('/0/private/TradesHistory');
     const rows = Object.values(res.trades ?? {}) as any[];
     info(`[Trades] Loaded ${rows.length} trades from API`);
@@ -88,6 +89,7 @@ function appendTotals(list: TradeItem[]): TradeResult {
 const isEurPair = (p: string) => /E?EUR$/i.test(p);
 
 export async function showBuys(): Promise<TradeResult> {
+    info('[Trades] showBuys start');
     const proRows = await loadTradesRaw();
     const proItems = proRows
         .filter(r => r.type === 'buy' && isEurPair(r.pair))
@@ -100,6 +102,7 @@ export async function showBuys(): Promise<TradeResult> {
 }
 
 export async function showSells(): Promise<TradeResult> {
+    info('[Trades] showSells start');
     const items = (await loadTradesRaw())
         .filter(r => r.type === 'sell' && isEurPair(r.pair))
         .map(mapTrade);
@@ -110,6 +113,7 @@ export async function showSells(): Promise<TradeResult> {
 // trade.ts - DEBUGGING-VERSION zum Loggen der API-Antwort
 
 export async function showCoinSummary(): Promise<CoinSummary[]> {
+    info('[Trades] showCoinSummary start');
     const proRows = await loadTradesRaw();
     const instantRows = await getInstantTrades();
     const baseFees = await getBaseFees();
@@ -163,6 +167,8 @@ export async function showCoinSummary(): Promise<CoinSummary[]> {
         if(b.buyVolume > 0) b.avgBuyPrice = b.buyCost / b.buyVolume;
         if(b.sellVolume > 0) b.avgSellPrice = b.sellProceeds / b.sellVolume;
     }
+
+    info(`[Trades] Coin summary bucket built: ${Object.keys(bucket).length} assets`);
 
     // --- Preisabfrage (unverändert) ---
     const assetsInBucket = Object.keys(bucket);


### PR DESCRIPTION
## Summary
- log when key functions start so we can trace execution
- log number of summarised assets in showCoinSummary

## Testing
- `npm run build:server` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68612bea9154832a90e4d77856f9dfed