### PR TITLE
Centralize type definitions

### DIFF
--- a/client/src/DataPage.tsx
+++ b/client/src/DataPage.tsx
@@ -5,93 +5,17 @@ import Notes from "./Notes";
 import { apiUrl } from "./utils/api";
 import AssetValueTable from "./components/AssetValueTable";
 import ProfitTable from "./components/ProfitTable";
-
-export interface AssetValue {
-    asset: string;
-    balance: number;
-    priceInEur: number;
-    eurValue: number;
-    sharePct: number;
-}
-
-export interface Ledger {
-    time: number;
-    asset: string;
-    type: string;
-    subtype?: string;
-    amount: string;
-    fee: string;
-    balance: string;
-    refid: string;
-};
-
-export interface TradeBalance {
-    eb: string;
-    tb: string;
-    m: string;
-    n: string;
-    c: string;
-    v: string;
-    e: string;
-    mf: string;
-    ml: string;
-}
-
-export interface Trade {
-    time: number;
-    pair: string;
-    type: 'buy' | 'sell';
-    ordertype: string;
-    price: string;
-    vol: string;
-    cost: string;
-    fee: string;
-    ordertxid: string;
-};
-
-export interface AverageBuyPricesStats {
-    totalVolume: number;
-    totalCostEur: number;
-    totalFeesEur: number;
-    averagePriceEur: number;
-}
-
-export interface FundingSummaryStats {
-    totalDeposited: number;
-    totalWithdrawn: number;
-    net: number;
-    fees: number;
-}
-
-export interface AverageSellPricesStats {
-    totalVolume: number;
-    totalRevenueEur: number;
-    totalFeesEur: number;
-    averagePriceEur: number;
-}
-
-export interface PnlStats {
-    investedEur: number;
-    realizedEur: number;
-    unrealizedEur: number;
-    totalEur: number;
-    totalPct: number;
-}
-export interface AllData {
-    accountBalance: Record<string, { balance: string; hold_trade: string }>;
-    tradeBalance: TradeBalance;
-    tradesHistory: { trades: Record<string, Trade> };
-    ledgers: Ledger[];
-    calculatedAssets: AssetValue[];
-    totalValueEur: number;
-    averageBuyPrices: Record<string, AverageBuyPricesStats>;
-    averageSellPrices: Record<string, AverageSellPricesStats>;
-    fundingSummary: Record<string, FundingSummaryStats>;
-    profitPerAsset: Record<string, PnlStats>;
-    profitTotals: PnlStats;
-    cached: boolean;
-    generatedAt: number;
-}
+import type {
+    AssetValue,
+    Ledger,
+    TradeBalance,
+    Trade,
+    AverageBuyPricesStats,
+    FundingSummaryStats,
+    AverageSellPricesStats,
+    PnlStats,
+    AllData,
+} from "./types";
 
 const BalanceExTable = ({ balanceData }: { balanceData: Record<string, { balance: string; hold_trade: string; }> }) => {
     const sortedEntries = Object.entries(balanceData)

--- a/client/src/Notes.tsx
+++ b/client/src/Notes.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { apiUrl } from "./utils/api";
-
-interface NotesResponse {
-    text: string;
-}
+import type { NotesResponse } from "./types";
 
 export default function Notes() {
     const [text, setText] = useState('');

--- a/client/src/components/AssetValueTable.tsx
+++ b/client/src/components/AssetValueTable.tsx
@@ -1,13 +1,6 @@
 import SortableTable from "./SortTable";
 import { fmt, fmtEuro } from "../utils/fmt";
-
-export interface AssetValue {
-    asset: string;
-    balance: number;
-    priceInEur: number;
-    eurValue: number;
-    sharePct: number;
-}
+import type { AssetValue } from "../types";
 
 const columns = [
     {

--- a/client/src/components/ProfitTable.tsx
+++ b/client/src/components/ProfitTable.tsx
@@ -1,17 +1,7 @@
 import React from "react";
 import SortableTable from "./SortTable";
 import { fmt, fmtEuro } from '../utils/fmt';
-
-export interface PnlStats {
-    investedEur: number;
-    realizedEur: number;
-    unrealizedEur: number;
-    totalEur: number;
-    totalPct: number;
-}
-interface Row extends PnlStats {
-    asset: string;
-}
+import type { PnlStats, PnlRow } from "../types";
 
 const cls = (v: number) => (v >= 0 ? 'gain' : 'loss');
 
@@ -25,13 +15,13 @@ const columns = [
         key: 'investedEur',
         label: <>Invested<Info text={`Buys - Sells (net cash flow)\nincl. buy & sell fees`} /></>,
         numeric: true,
-        render: (r: Row) => fmtEuro(r.investedEur),
+        render: (r: PnlRow) => fmtEuro(r.investedEur),
     },
     {
         key: 'realizedEur',
         label: <>Realized<Info text={`Gain / Loss on SOLD coins\nnet after buy & sell fees`} /></>,
         numeric: true,
-        render: (r: Row) => (
+        render: (r: PnlRow) => (
             <span className={cls(r.realizedEur)}>{fmtEuro(r.realizedEur)}</span>
         ),
     },
@@ -39,7 +29,7 @@ const columns = [
         key: 'unrealizedEur',
         label: <>Unrealized<Info text={`Market value - cost basis of current coins\nCost basis = current balance × avg. buy price\n(avg. buy price already incl. buy fees)`} /></>,
         numeric: true,
-        render: (r: Row) => (
+        render: (r: PnlRow) => (
             <span className={cls(r.unrealizedEur)}>{fmtEuro(r.unrealizedEur)}</span>
         ),
     },
@@ -47,7 +37,7 @@ const columns = [
         key: 'totalEur',
         label: <>Total<Info text={`Realized + Unrealized\n(all fees already included)`} /></>,
         numeric: true,
-        render: (r: Row) => (
+        render: (r: PnlRow) => (
             <span className={cls(r.totalEur)}>{fmtEuro(r.totalEur)}</span>
         ),
     },
@@ -55,7 +45,7 @@ const columns = [
         key: 'totalPct',
         label: <>Total %<Info text={`Total / Invested\n(all fees already included)`} /></>,
         numeric: true,
-        render: (r: Row) => (
+        render: (r: PnlRow) => (
             <span className={cls(r.totalPct)}>{fmt(r.totalPct, 2)} %</span>
         ),
     },
@@ -68,19 +58,19 @@ export default function ProfitTable({
     stats: Record<string, PnlStats>;
     totals: PnlStats;
 }) {
-    const rows: Row[] = Object.entries(stats)
+    const rows: PnlRow[] = Object.entries(stats)
         .map(([asset, s]) => ({ asset, ...s }))
         .sort((a, b) => b.totalEur - a.totalEur);
 
     if (!rows.length) return null;
 
-    const footer: Row = { asset: 'Total', ...totals };
+    const footer: PnlRow = { asset: 'Total', ...totals };
 
     return (
         <section>
             <h2>Realized / Unrealized per Coin</h2>
 
-            <SortableTable<Row>
+            <SortableTable<PnlRow>
                 data={rows}
                 columns={columns}
                 initialSort={{ key: 'totalEur', dir: 'desc' }}

--- a/client/src/components/SortTable.tsx
+++ b/client/src/components/SortTable.tsx
@@ -1,22 +1,6 @@
 import React from "react";
-import { useSort, type SortConfig, type SortDir } from "./useSort";
-
-type RowObj = Record<string, unknown>;
-
-interface Column<T extends RowObj> {
-    key: keyof T;
-    label: React.ReactNode;
-    numeric?: boolean;
-    render?: (row: T) => React.ReactNode;
-    sortable?: boolean;
-}
-
-interface Props<T extends RowObj> {
-    data: readonly[];
-    columns: readonly Column<T>[];
-    initialSort?: SortConfig<T>;
-    footer?: T;
-}
+import { useSort } from "./useSort";
+import type { SortConfig, SortDir, RowObj, Column, SortTableProps } from "../types";
 
 function Arrow({
     active,
@@ -37,7 +21,7 @@ export default function SortableTable<T extends RowObj>({
     columns,
     initialSort,
     footer,
-}: Props<T>) {
+}: SortTableProps<T>) {
     const { sorted, sort, requestSort } = useSort(data, initialSort);
 
     return (

--- a/client/src/components/useSort.ts
+++ b/client/src/components/useSort.ts
@@ -1,11 +1,5 @@
 import { useState, useCallback } from "react";
-
-export type SortDir = 'asc' | 'desc';
-
-export interface SortConfig<T = unknown> {
-    key: keyof T;
-    dir: SortDir;
-}
+import type { SortDir, SortConfig } from "../types";
 
 export function useSort<T extends object>(
     data: readonly T[],

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,119 @@
+export interface AssetValue {
+    asset: string;
+    balance: number;
+    priceInEur: number;
+    eurValue: number;
+    sharePct: number;
+}
+
+export interface Ledger {
+    time: number;
+    asset: string;
+    type: string;
+    subtype?: string;
+    amount: string;
+    fee: string;
+    balance: string;
+    refid: string;
+}
+
+export interface TradeBalance {
+    eb: string;
+    tb: string;
+    m: string;
+    n: string;
+    c: string;
+    v: string;
+    e: string;
+    mf: string;
+    ml: string;
+}
+
+export interface Trade {
+    time: number;
+    pair: string;
+    type: 'buy' | 'sell';
+    ordertype: string;
+    price: string;
+    vol: string;
+    cost: string;
+    fee: string;
+    ordertxid: string;
+}
+
+export interface AverageBuyPricesStats {
+    totalVolume: number;
+    totalCostEur: number;
+    totalFeesEur: number;
+    averagePriceEur: number;
+}
+
+export interface FundingSummaryStats {
+    totalDeposited: number;
+    totalWithdrawn: number;
+    net: number;
+    fees: number;
+}
+
+export interface AverageSellPricesStats {
+    totalVolume: number;
+    totalRevenueEur: number;
+    totalFeesEur: number;
+    averagePriceEur: number;
+}
+
+export interface PnlStats {
+    investedEur: number;
+    realizedEur: number;
+    unrealizedEur: number;
+    totalEur: number;
+    totalPct: number;
+}
+
+export interface AllData {
+    accountBalance: Record<string, { balance: string; hold_trade: string }>;
+    tradeBalance: TradeBalance;
+    tradesHistory: { trades: Record<string, Trade> };
+    ledgers: Ledger[];
+    calculatedAssets: AssetValue[];
+    totalValueEur: number;
+    averageBuyPrices: Record<string, AverageBuyPricesStats>;
+    averageSellPrices: Record<string, AverageSellPricesStats>;
+    fundingSummary: Record<string, FundingSummaryStats>;
+    profitPerAsset: Record<string, PnlStats>;
+    profitTotals: PnlStats;
+    cached: boolean;
+    generatedAt: number;
+}
+
+export interface NotesResponse {
+    text: string;
+}
+
+export type SortDir = 'asc' | 'desc';
+
+export interface SortConfig<T = unknown> {
+    key: keyof T;
+    dir: SortDir;
+}
+
+export type RowObj = Record<string, unknown>;
+
+export interface Column<T extends RowObj> {
+    key: keyof T;
+    label: React.ReactNode;
+    numeric?: boolean;
+    render?: (row: T) => React.ReactNode;
+    sortable?: boolean;
+}
+
+export interface SortTableProps<T extends RowObj> {
+    data: readonly T[];
+    columns: readonly Column<T>[];
+    initialSort?: SortConfig<T>;
+    footer?: T;
+}
+
+export interface PnlRow extends PnlStats {
+    asset: string;
+}

--- a/server/src/calculations.ts
+++ b/server/src/calculations.ts
@@ -1,77 +1,19 @@
 import { info } from "./utils/logger";
 import { mapKrakenAsset, getTickerBase } from "./utils/assetMapper";
 import { extractPrice } from "./utils/extractPrice";
-
-export interface AssetValue {
-    asset: string;
-    balance: number;
-    priceInEur: number;
-    eurValue: number;
-    sharePct: number;
-}
-
-export interface CalculatedPortfolio {
-    assets: AssetValue[];
-    totalValueEur: number;
-}
-
-export interface AverageBuyPriceStats {
-    totalVolume: number;
-    totalCostEur: number;
-    totalFeesEur: number;
-    averagePriceEur: number;
-}
-
-export interface FundingSummaryStats {
-    totalDeposited: number;
-    totalWithdrawn: number;
-    net: number;
-    fees: number;
-}
-
-export interface AverageSellPriceStats {
-    totalVolume: number;
-    totalRevenueEur: number;
-    totalFeesEur: number;
-    averagePriceEur: number;
-}
-
-export interface PnlStats {
-    investedEur: number;
-    realizedEur: number;
-    unrealizedEur: number;
-    totalEur: number;
-    totalPct: number;
-}
-
-export interface PnlPerAssetResult {
-    perAsset: Record<string, PnlStats>;
-    totals: PnlStats;
-}
-
-interface KrakenTicker {
-    c?: [string, string];
-    a?: [string, string];
-    b?: [string, string];
-}
-
-interface KrakenTrade {
-    type: 'buy' | 'sell';
-    pair: string;
-    vol: string;
-    cost: string;
-    fee: string;
-}
-
-interface LedgerEntry {
-    refid: string;
-    type: string;
-    asset: string;
-    amount: string;
-    fee?: string;
-}
-
-type KrakenTickerMap = Record<string, KrakenTicker>;
+import {
+    AssetValue,
+    CalculatedPortfolio,
+    AverageBuyPriceStats,
+    FundingSummaryStats,
+    AverageSellPriceStats,
+    PnlStats,
+    PnlPerAssetResult,
+    KrakenTicker,
+    KrakenTrade,
+    LedgerEntry,
+    KrakenTickerMap,
+} from "./types";
 
 function usdToEur(prices: KrakenTickerMap): number | null {
     const pairs = ['EURUSD', 'USDEUR', 'USDZEUR'] as const;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,50 +8,21 @@ import {
     calculateAverageSellPrices,
     calculateFundingSummary,
     calculatePnlPerAsset,
-    type AverageBuyPriceStats,
-    type AverageSellPriceStats,
-    type FundingSummaryStats
 } from './calculations';
 import { withCache } from './utils/cache';
 import { readNotes, writeNotes } from './notesStorage';
-
-interface LedgerEntry {
-    refid: string;
-    type: string;
-    asset: string;
-    amount: string;
-    fee?: string;
-}
-
-interface KrakenTrade {
-    type: 'buy' | 'sell';
-    pair: string;
-    vol: string;
-    cost: string;
-    fee: string;
-}
-
-interface TradesHistory {
-    trades: Record<string, KrakenTrade>;
-}
-
-type AccountBalance = Record<string, { balance: string; hold_trade?: string }>;
-type TradeBalance = Record<string, string>;
-
-interface AllData {
-    accountBalance: AccountBalance;
-    tradeBalance: TradeBalance;
-    tradesHistory: TradesHistory;
-    ledgers: LedgerEntry[];
-    calculatedAssets: ReturnType<typeof calculateAssetsValue>['assets'];
-    totalValueEur: number;
-    averageBuyPrices: Record<string, AverageBuyPriceStats>;
-    averageSellPrices: Record<string, AverageSellPriceStats>;
-    fundingSummary: Record<string, FundingSummaryStats>;
-    profitPerAsset: ReturnType<typeof calculatePnlPerAsset>['perAsset'];
-    profitTotals: ReturnType<typeof calculatePnlPerAsset>['totals']
-    generatedAt: number;
-}
+import {
+    AverageBuyPriceStats,
+    AverageSellPriceStats,
+    FundingSummaryStats,
+    LedgerEntry,
+    KrakenTrade,
+    TradesHistory,
+    AccountBalance,
+    TradeBalance,
+    AllData,
+    NotesBody,
+} from './types';
 
 const app = express();
 const port = process.env.PORT ?? 3000;
@@ -101,8 +72,6 @@ app.get('/api/notes', async (_req, res) => {
     const text = await readNotes();
     res.json({ text });
 });
-
-interface NotesBody { text?: string };
 
 app.post('/api/notes', async (req: Request<unknown, unknown, NotesBody>, res) => {
     await writeNotes(req.body?.text ?? '');

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,101 @@
+export interface AssetValue {
+    asset: string;
+    balance: number;
+    priceInEur: number;
+    eurValue: number;
+    sharePct: number;
+}
+
+export interface CalculatedPortfolio {
+    assets: AssetValue[];
+    totalValueEur: number;
+}
+
+export interface AverageBuyPriceStats {
+    totalVolume: number;
+    totalCostEur: number;
+    totalFeesEur: number;
+    averagePriceEur: number;
+}
+
+export interface FundingSummaryStats {
+    totalDeposited: number;
+    totalWithdrawn: number;
+    net: number;
+    fees: number;
+}
+
+export interface AverageSellPriceStats {
+    totalVolume: number;
+    totalRevenueEur: number;
+    totalFeesEur: number;
+    averagePriceEur: number;
+}
+
+export interface PnlStats {
+    investedEur: number;
+    realizedEur: number;
+    unrealizedEur: number;
+    totalEur: number;
+    totalPct: number;
+}
+
+export interface PnlPerAssetResult {
+    perAsset: Record<string, PnlStats>;
+    totals: PnlStats;
+}
+
+export interface KrakenTicker {
+    c?: [string, string];
+    a?: [string, string];
+    b?: [string, string];
+}
+
+export interface KrakenTrade {
+    type: 'buy' | 'sell';
+    pair: string;
+    vol: string;
+    cost: string;
+    fee: string;
+}
+
+export interface LedgerEntry {
+    refid: string;
+    type: string;
+    asset: string;
+    amount: string;
+    fee?: string;
+}
+
+export type KrakenTickerMap = Record<string, KrakenTicker>;
+
+export interface PriceQuote {
+    price: number;
+    ts: string;
+}
+
+export type CacheEntry<T> = { value: T; ts: number };
+
+export interface TradesHistory {
+    trades: Record<string, KrakenTrade>;
+}
+
+export type AccountBalance = Record<string, { balance: string; hold_trade?: string }>;
+export type TradeBalance = Record<string, string>;
+
+export interface AllData {
+    accountBalance: AccountBalance;
+    tradeBalance: TradeBalance;
+    tradesHistory: TradesHistory;
+    ledgers: LedgerEntry[];
+    calculatedAssets: AssetValue[];
+    totalValueEur: number;
+    averageBuyPrices: Record<string, AverageBuyPriceStats>;
+    averageSellPrices: Record<string, AverageSellPriceStats>;
+    fundingSummary: Record<string, FundingSummaryStats>;
+    profitPerAsset: Record<string, PnlStats>;
+    profitTotals: PnlStats;
+    generatedAt: number;
+}
+
+export interface NotesBody { text?: string }

--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -1,9 +1,8 @@
 import { info } from "./logger";
-
-type Entry<T> = { value: T; ts: number };
+import { CacheEntry } from "../types";
 
 export function withCache<T>(ttlMs: number, fn: () => Promise<T>) {
-    let entry: Entry<T> | null = null;
+    let entry: CacheEntry<T> | null = null;
 
     return async (): Promise<T & { cached: boolean }> => {
         const now = Date.now();

--- a/server/src/utils/kraken.ts
+++ b/server/src/utils/kraken.ts
@@ -21,10 +21,6 @@ if (!KEY || !SECRET) {
     process.exit(1);
 }
 
-export interface PriceQuote {
-    price: number;
-    ts: string;
-}
 
 function sign(path: string, params: URLSearchParams, secretB64: string): string {
     const nonce = params.get('nonce')!;


### PR DESCRIPTION
## Summary
- create server/src/types.ts with shared interfaces and aliases
- create client/src/types.ts for frontend types
- refactor modules to import from central types files

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe call of a(n) `any` typed value, Unexpected any, etc.)*
- `pre-commit run --files server/src/types.ts server/src/calculations.ts server/src/utils/cache.ts server/src/utils/kraken.ts server/src/server.ts client/src/types.ts client/src/DataPage.tsx client/src/Notes.tsx client/src/components/useSort.ts client/src/components/AssetValueTable.tsx client/src/components/ProfitTable.tsx client/src/components/SortTable.tsx` *(fails: URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)>)*

------
https://chatgpt.com/codex/tasks/task_e_688f9c83c054832aa7ccc348d26e3dfd